### PR TITLE
Normalize section headers in KNN lab

### DIFF
--- a/KNN Lab.ipynb
+++ b/KNN Lab.ipynb
@@ -210,7 +210,7 @@
         "id": "S2NDEGxgSTD7"
       },
       "source": [
-        "#### Comparison and Discussion"
+        "#### *Comparison and Discussion*"
       ]
     },
     {

--- a/KNN Lab.ipynb
+++ b/KNN Lab.ipynb
@@ -1,382 +1,545 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "DVL7_bgmIAPR"
-   },
-   "source": [
-    "# K-Nearest Neighbor Lab\n",
-    "Read over the sklearn info on [nearest neighbor learners](https://scikit-learn.org/stable/modules/neighbors.html#nearest-neighbors-classification)\n",
-    "\n",
-    "\n"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "DVL7_bgmIAPR"
+      },
+      "source": [
+        "# K-Nearest Neighbor Lab\n",
+        "Read over the sklearn info on [nearest neighbor learners](https://scikit-learn.org/stable/modules/neighbors.html#nearest-neighbors-classification)\n",
+        "\n",
+        "\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "6ZbYjZZZ_yLV"
+      },
+      "outputs": [],
+      "source": [
+        "from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor\n",
+        "import numpy as np\n",
+        "import pandas as pd\n",
+        "from scipy.io import arff\n",
+        "import matplotlib.pyplot as plt\n",
+        "from sklearn.model_selection import train_test_split"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## 1 K-Nearest Neighbor (KNN) algorithm"
+      ],
+      "metadata": {
+        "id": "3leafOMASaMD"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### 1.1 (15%) Basic KNN Classification"
+      ],
+      "metadata": {
+        "id": "PGvXPAWQScwX"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "2ZNdpgBwSTD4"
+      },
+      "source": [
+        "Learn the [Glass data set](https://archive.ics.uci.edu/dataset/42/glass+identification) using [KNeighborsClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KNeighborsClassifier.html#sklearn.neighbors.KNeighborsClassifier) with default parameters.\n",
+        "- Randomly split your data into train/test.  Anytime we don't tell you specifics (such as what percentage is train vs test) choose your own reasonable values\n",
+        "- Give typical train and test set accuracies after running with different random splits\n",
+        "- Print the output probabilities for a test set (predict_proba)\n",
+        "- Try it with different p values (Minkowskian exponent) and discuss any differences"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "8-g8b_1eSTD5"
+      },
+      "outputs": [],
+      "source": [
+        "# Learn the glass data"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "qGI2rA7WSTD5"
+      },
+      "source": [
+        "#### *Discussion*"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## 2 KNN Classification with normalization and distance weighting"
+      ],
+      "metadata": {
+        "id": "OB_U_3EmSr_W"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Use the [magic telescope](https://axon.cs.byu.edu/data/uci_class/MagicTelescope.arff) dataset."
+      ],
+      "metadata": {
+        "id": "qu5oFxLLSqNh"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### 2.1 (5%) - Without Normalization or Distance Weighting"
+      ],
+      "metadata": {
+        "id": "sxfXj1dISn89"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "9vWiTdlbR2Xh"
+      },
+      "source": [
+        "- Do random 80/20 train/test splits each time\n",
+        "- Run with k=3 and *without* distance weighting and *without* normalization\n",
+        "- Show train and test set accuracy"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "4SSoasDQSKXb"
+      },
+      "outputs": [],
+      "source": [
+        "# Learn magic telescope data"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "c6imGxWWSTD5"
+      },
+      "source": [
+        "#### *Discussion*"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### 2.2 (10%) With Normalization"
+      ],
+      "metadata": {
+        "id": "oztaHpczSyMb"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "WAfqhWP3STD6"
+      },
+      "source": [
+        "- Try it with k=3 without distance weighting but *with* normalization of input features.  You may use any reasonable normalization approach (e.g. standard min-max normalization between 0-1, z-transform, etc.)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "-6RutSEGSTD6"
+      },
+      "outputs": [],
+      "source": [
+        "# Train/Predict with normalization"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "idwNK9R_STD6"
+      },
+      "source": [
+        "#### *Discuss the results of using normalized data vs. unnormalized data*"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### 2.3 (10%) With Distance Weighting"
+      ],
+      "metadata": {
+        "id": "6vxiKEtXS1QS"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "vmlxgwYgSTD6"
+      },
+      "source": [
+        "- Try it with k=3 and with distance weighting *and* normalization"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "XF8rLse4STD6"
+      },
+      "outputs": [],
+      "source": [
+        "#Train/Precdict with normalization and distance weighting"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "S2NDEGxgSTD7"
+      },
+      "source": [
+        "#### Comparison and Discussion"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### 2.4 (10%) Different k Values"
+      ],
+      "metadata": {
+        "id": "VjC4WOVXTaY2"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "VK376R9dSTD7"
+      },
+      "source": [
+        "- Using your normalized data with distance weighting, create one graph with classification accuracy on the test set on the y-axis and k values on the x-axis.\n",
+        "- Use values of k from 1 to 15.  Use the same train/test split for each."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Ewf2JXH0STD7"
+      },
+      "outputs": [],
+      "source": [
+        "# Calculate and Graph classification accuracy vs k values"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ElI5uO2xSTD7"
+      },
+      "source": [
+        "#### *Discussion*"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## 3 KNN Regression with normalization and distance weighting"
+      ],
+      "metadata": {
+        "id": "9ef9V2tqTlz0"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Use the [sklean KNeighborsRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KNeighborsRegressor.html#sklearn.neighbors.KNeighborsRegressor) on the [housing price prediction](https://axon.cs.byu.edu/data/uci_regression/housing.arff) problem."
+      ],
+      "metadata": {
+        "id": "xQTD5tJKTid-"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### 3.1 (5%) Ethical Data"
+      ],
+      "metadata": {
+        "id": "IaedsjRTTf2g"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "SIRG42TgSR4x"
+      },
+      "source": [
+        "Note this data set has an example of an inappropriate input feature which we discussed.  State which feature is inappropriate and discuss why."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "X74i07GjSTD7"
+      },
+      "source": [
+        "#### *Discuss the innapropriate feature*"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### 3.2 (15%) - KNN Regression"
+      ],
+      "metadata": {
+        "id": "_u3u4_z5Tt7j"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "2M-s4cT4STD7"
+      },
+      "source": [
+        "- Do random 80/20 train/test splits each time\n",
+        "- Run with k=3\n",
+        "- Print the score (coefficient of determination) and Mean Absolute Error (MAE) for the train and test set for the cases of\n",
+        "  - No input normalization and no distance weighting\n",
+        "  - Normalization and no distance weighting\n",
+        "  - Normalization and distance weighting\n",
+        "- Normalize inputs features where needed but do not normalize the output"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "KBGUn43ASiXW"
+      },
+      "outputs": [],
+      "source": [
+        "# Learn and experiment with housing price prediction data"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "9onJv13iSTD7"
+      },
+      "source": [
+        "#### *Discuss your results*"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "### 3.3 (10%)  Different k Values"
+      ],
+      "metadata": {
+        "id": "EBN5s3jrUATm"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "pMnT5gd0STD7"
+      },
+      "source": [
+        "- Using housing with normalized data and distance weighting, create one graph with MAE on the test set on the y-axis and k values on the x-axis\n",
+        "- Use values of k from 1 to 15.  Use the same train/test split for each."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "iQ63IqfFSTD8"
+      },
+      "outputs": [],
+      "source": [
+        "# Learn and graph for different k values"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "WkZkyvLkSTD8"
+      },
+      "source": [
+        "#### *Discussion*"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## 4 (20%) KNN with nominal and real data"
+      ],
+      "metadata": {
+        "id": "UZ7YqOq5UEC7"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "Q6VAoijZSTD8"
+      },
+      "source": [
+        "- Use the [lymph dataset](https://axon.cs.byu.edu/data/uci_class/lymph.arff)\n",
+        "- Use a 80/20 split of the data for the training/test set\n",
+        "- This dataset has both continuous and nominal attributes\n",
+        "- Implement a distance metric which uses Euclidean distance for continuous features and 0/1 distance for nominal. Hints:\n",
+        "    - Write your own distance function (e.g. mydist) and use clf = KNeighborsClassifier(metric=mydist)\n",
+        "    - Change the nominal features in the data set to integer values since KNeighborsClassifier expects numeric features. I used Label_Encoder on the nominal features.\n",
+        "    - Keep a list of which features are nominal which mydist can use to decide which distance measure to use\n",
+        "    - There was an occasional bug in SK version 1.3.0 (\"Flags object has no attribute 'c_contiguous'\") that went away when I upgraded to the lastest SK version 1.3.1\n",
+        "- Use your own choice for k and other parameters"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "aFxlAhmMSTD8"
+      },
+      "outputs": [],
+      "source": [
+        "# Train/Predict lymph with your own distance metric"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "fuhL56KMSTD8"
+      },
+      "source": [
+        "#### *Explain your distance metric and discuss your results*"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## 5 (Optional 15% extra credit) Code up your own KNN Learner"
+      ],
+      "metadata": {
+        "id": "O2ZREVbJUMMv"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ts8GlCEjSTD8"
+      },
+      "source": [
+        "Below is a scaffold you could use if you want. Requirements for this task:\n",
+        "- Your model should support the methods shown in the example scaffold below\n",
+        "- Use Euclidean distance to decide closest neighbors\n",
+        "- Implement both the classification and regression versions\n",
+        "- Include optional distance weighting for both algorithms\n",
+        "- Run your algorithm on the magic telescope and housing data sets above and discuss and compare your results"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "BSSzFGLOSTD8"
+      },
+      "source": [
+        "#### *Discussion*"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "hSx5kgA5STD8"
+      },
+      "outputs": [],
+      "source": [
+        "from sklearn.base import BaseEstimator, ClassifierMixin\n",
+        "\n",
+        "class KNNClassifier(BaseEstimator,ClassifierMixin):\n",
+        "    def __init__(self, columntype=[], weight_type='inverse_distance'): ## add parameters here\n",
+        "        \"\"\"\n",
+        "        Args:\n",
+        "            columntype for each column tells you if continues[real] or if nominal[categoritcal].\n",
+        "            weight_type: inverse_distance voting or if non distance weighting. Options = [\"no_weight\",\"inverse_distance\"]\n",
+        "        \"\"\"\n",
+        "        self.columntype = columntype #Note This won't be needed until part 5\n",
+        "        self.weight_type = weight_type\n",
+        "\n",
+        "    def fit(self, data, labels):\n",
+        "        \"\"\" Fit the data; run the algorithm (for this lab really just saves the data :D)\n",
+        "        Args:\n",
+        "            X (array-like): A 2D numpy array with the training data, excluding targets\n",
+        "            y (array-like): A 2D numpy array with the training targets\n",
+        "        Returns:\n",
+        "            self: this allows this to be chained, e.g. model.fit(X,y).predict(X_test)\n",
+        "        \"\"\"\n",
+        "        return self\n",
+        "\n",
+        "    def predict(self, data):\n",
+        "        \"\"\" Predict all classes for a dataset X\n",
+        "        Args:\n",
+        "            X (array-like): A 2D numpy array with the training data, excluding targets\n",
+        "        Returns:\n",
+        "            array, shape (n_samples,)\n",
+        "                Predicted target values per element in X.\n",
+        "        \"\"\"\n",
+        "        pass\n",
+        "\n",
+        "    #Returns the Mean score given input data and labels\n",
+        "    def score(self, X, y):\n",
+        "        \"\"\" Return accuracy of model on a given dataset. Must implement own score function.\n",
+        "        Args:\n",
+        "            X (array-like): A 2D numpy array with data, excluding targets\n",
+        "            y (array-like): A 2D numpy array with targets\n",
+        "        Returns:\n",
+        "            score : float\n",
+        "                Mean accuracy of self.predict(X) wrt. y.\n",
+        "        \"\"\"\n",
+        "        return 0"
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "name": "lab 1 - perceptron",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3.10.7 64-bit",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.10.7"
+    },
+    "vscode": {
+      "interpreter": {
+        "hash": "aee8b7b246df8f9039afb4144a1f6fd8d2ca17a180786b69acc140d282b71a49"
+      }
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "id": "6ZbYjZZZ_yLV"
-   },
-   "outputs": [],
-   "source": [
-    "from sklearn.neighbors import KNeighborsClassifier, KNeighborsRegressor\n",
-    "import numpy as np\n",
-    "import pandas as pd\n",
-    "from scipy.io import arff\n",
-    "import matplotlib.pyplot as plt\n",
-    "from sklearn.model_selection import train_test_split"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 1 K-Nearest Neighbor (KNN) algorithm\n",
-    "\n",
-    "### 1.1 (15%) Basic KNN Classification\n",
-    "\n",
-    "Learn the [Glass data set](https://archive.ics.uci.edu/dataset/42/glass+identification) using [KNeighborsClassifier](https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KNeighborsClassifier.html#sklearn.neighbors.KNeighborsClassifier) with default parameters.\n",
-    "- Randomly split your data into train/test.  Anytime we don't tell you specifics (such as what percentage is train vs test) choose your own reasonable values\n",
-    "- Give typical train and test set accuracies after running with different random splits\n",
-    "- Print the output probabilities for a test set (predict_proba)\n",
-    "- Try it with different p values (Minkowskian exponent) and discuss any differences"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Learn the glass data"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Discussion"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "9vWiTdlbR2Xh"
-   },
-   "source": [
-    "## 2 KNN Classification with normalization and distance weighting\n",
-    "\n",
-    "Use the [magic telescope](https://axon.cs.byu.edu/data/uci_class/MagicTelescope.arff) dataset\n",
-    "\n",
-    "### 2.1 (5%) - Without Normalization or Distance Weighting\n",
-    "- Do random 80/20 train/test splits each time\n",
-    "- Run with k=3 and *without* distance weighting and *without* normalization\n",
-    "- Show train and test set accuracy"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "id": "4SSoasDQSKXb"
-   },
-   "outputs": [],
-   "source": [
-    "# Learn magic telescope data"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "*Discussion*"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 2.2 (10%) With Normalization\n",
-    "- Try it with k=3 without distance weighting but *with* normalization of input features.  You may use any reasonable normalization approach (e.g. standard min-max normalization between 0-1, z-transform, etc.)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Train/Predict with normalization"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "*Discuss the results of using normalized data vs. unnormalized data*"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 2.3 (10%) With Distance Weighting\n",
-    "- Try it with k=3 and with distance weighting *and* normalization"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#Train/Precdict with normalization and distance weighting"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Comparison and Discussion"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 2.4 (10%) Different k Values\n",
-    "- Using your normalized data with distance weighting, create one graph with classification accuracy on the test set on the y-axis and k values on the x-axis.\n",
-    "- Use values of k from 1 to 15.  Use the same train/test split for each. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Calculate and Graph classification accuracy vs k values"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "*Discussion*"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "SIRG42TgSR4x"
-   },
-   "source": [
-    "## 3 KNN Regression with normalization and distance weighting\n",
-    "\n",
-    "Use the [sklean KNeighborsRegressor](https://scikit-learn.org/stable/modules/generated/sklearn.neighbors.KNeighborsRegressor.html#sklearn.neighbors.KNeighborsRegressor) on the [housing price prediction](https://axon.cs.byu.edu/data/uci_regression/housing.arff) problem.  \n",
-    "### 3.1 (5%) Ethical Data\n",
-    "Note this data set has an example of an inappropriate input feature which we discussed.  State which feature is inappropriate and discuss why."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "*Discuss the innapropriate feature*"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 3.2 (15%) - KNN Regression \n",
-    "- Do random 80/20 train/test splits each time\n",
-    "- Run with k=3\n",
-    "- Print the score (coefficient of determination) and Mean Absolute Error (MAE) for the train and test set for the cases of\n",
-    "  - No input normalization and no distance weighting\n",
-    "  - Normalization and no distance weighting\n",
-    "  - Normalization and distance weighting\n",
-    "- Normalize inputs features where needed but do not normalize the output"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {
-    "id": "KBGUn43ASiXW"
-   },
-   "outputs": [],
-   "source": [
-    "# Learn and experiment with housing price prediction data"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "*Discuss your results*"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### 3.3 (10%)  Different k Values\n",
-    "- Using housing with normalized data and distance weighting, create one graph with MAE on the test set on the y-axis and k values on the x-axis\n",
-    "- Use values of k from 1 to 15.  Use the same train/test split for each. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Learn and graph for different k values"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Discussion"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 4. (20%) KNN with nominal and real data\n",
-    "\n",
-    "- Use the [lymph dataset](https://axon.cs.byu.edu/data/uci_class/lymph.arff)\n",
-    "- Use a 80/20 split of the data for the training/test set\n",
-    "- This dataset has both continuous and nominal attributes \n",
-    "- Implement a distance metric which uses Euclidean distance for continuous features and 0/1 distance for nominal. Hints:\n",
-    "    - Write your own distance function (e.g. mydist) and use clf = KNeighborsClassifier(metric=mydist)\n",
-    "    - Change the nominal features in the data set to integer values since KNeighborsClassifier expects numeric features. I used Label_Encoder on the nominal features.\n",
-    "    - Keep a list of which features are nominal which mydist can use to decide which distance measure to use\n",
-    "    - There was an occasional bug in SK version 1.3.0 (\"Flags object has no attribute 'c_contiguous'\") that went away when I upgraded to the lastest SK version 1.3.1 \n",
-    "- Use your own choice for k and other parameters"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Train/Predict lymph with your own distance metric"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "*Explain your distance metric and discuss your results*"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 5. (Optional 15% extra credit) Code up your own KNN Learner \n",
-    "Below is a scaffold you could use if you want. Requirements for this task:\n",
-    "- Your model should support the methods shown in the example scaffold below\n",
-    "- Use Euclidean distance to decide closest neighbors\n",
-    "- Implement both the classification and regression versions\n",
-    "- Include optional distance weighting for both algorithms\n",
-    "- Run your algorithm on the magic telescope and housing data sets above and discuss and compare your results "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "*Discussion*"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from sklearn.base import BaseEstimator, ClassifierMixin\n",
-    "\n",
-    "class KNNClassifier(BaseEstimator,ClassifierMixin):\n",
-    "    def __init__(self, columntype=[], weight_type='inverse_distance'): ## add parameters here\n",
-    "        \"\"\"\n",
-    "        Args:\n",
-    "            columntype for each column tells you if continues[real] or if nominal[categoritcal].\n",
-    "            weight_type: inverse_distance voting or if non distance weighting. Options = [\"no_weight\",\"inverse_distance\"]\n",
-    "        \"\"\"\n",
-    "        self.columntype = columntype #Note This won't be needed until part 5\n",
-    "        self.weight_type = weight_type\n",
-    "\n",
-    "    def fit(self, data, labels):\n",
-    "        \"\"\" Fit the data; run the algorithm (for this lab really just saves the data :D)\n",
-    "        Args:\n",
-    "            X (array-like): A 2D numpy array with the training data, excluding targets\n",
-    "            y (array-like): A 2D numpy array with the training targets\n",
-    "        Returns:\n",
-    "            self: this allows this to be chained, e.g. model.fit(X,y).predict(X_test)\n",
-    "        \"\"\"\n",
-    "        return self\n",
-    "    \n",
-    "    def predict(self, data):\n",
-    "        \"\"\" Predict all classes for a dataset X\n",
-    "        Args:\n",
-    "            X (array-like): A 2D numpy array with the training data, excluding targets\n",
-    "        Returns:\n",
-    "            array, shape (n_samples,)\n",
-    "                Predicted target values per element in X.\n",
-    "        \"\"\"\n",
-    "        pass\n",
-    "\n",
-    "    #Returns the Mean score given input data and labels\n",
-    "    def score(self, X, y):\n",
-    "        \"\"\" Return accuracy of model on a given dataset. Must implement own score function.\n",
-    "        Args:\n",
-    "            X (array-like): A 2D numpy array with data, excluding targets\n",
-    "            y (array-like): A 2D numpy array with targets\n",
-    "        Returns:\n",
-    "            score : float\n",
-    "                Mean accuracy of self.predict(X) wrt. y.\n",
-    "        \"\"\"\n",
-    "        return 0"
-   ]
-  }
- ],
- "metadata": {
-  "colab": {
-   "collapsed_sections": [],
-   "name": "lab 1 - perceptron",
-   "provenance": []
-  },
-  "kernelspec": {
-   "display_name": "Python 3.10.7 64-bit",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.7"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "aee8b7b246df8f9039afb4144a1f6fd8d2ca17a180786b69acc140d282b71a49"
-   }
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 4
+  "nbformat": 4,
+  "nbformat_minor": 0
 }


### PR DESCRIPTION
## Overview
Propose formatting _only_ adjustments to the document which enable ease-of-life improvements for students, especially those using Google Colab as an editor.

Hopefully, this PR can be approved before the majority of students begin the KNN lab.

## Motivation
Google Colab supports section folding, but it only works when each heading it in it's own "text" block.
Especially as we add lots of code and result output in between all the sections, it becomes difficult to scroll 
back and forth between the sections. Structuring the document enables students to code fold _if they wish_.

Additionally, Google Colab will generate an automatic "Document Outline," but it skips headings that look like  they begin lists. The sub-headers "3. *" and "4. *" are  therefore omitted. Simply removing the . character is enough to make this feature work properly.

Finally, this also standardizes the formatting of the "Discussion" prompts. Whereas they were previously  inconsistent, 
they are all now _italicized_ and marked as an H4. This causes them to show up in the document outline.

## Screenshots
1. Showing the handy-dandy "Document Outline"
![image](https://github.com/user-attachments/assets/f8b9532c-f7fe-4ed3-b3a8-3fa2bb1cdc6e)

2. Showing the document with sections collapsed (a helpful navigation feature)
![image](https://github.com/user-attachments/assets/07cd199e-77c1-49ea-9268-3c929627c59b)

## Details
I hoped the code diff would be minimal since I only changed a few details. However, since Google Colab formatted
the file with different whitespace, the `diff` view in the PR looks like lots of code was changed.

[**View this PR with whitespace differences disabled.**](https://github.com/BYU-CS-472/CS472/pull/18/files?diff=split&w=1)